### PR TITLE
[Issue-1] Remove JaxArrayWrapper

### DIFF
--- a/src/xarray_jax/__init__.py
+++ b/src/xarray_jax/__init__.py
@@ -7,11 +7,7 @@ from .xarray_jax import (
     assign_coords,
     get_jax_coords,
     assign_jax_coords,
-    wrap,  # Retained for now, though it's an identity function for JAX arrays
-    unwrap,
     unwrap_data,
-    unwrap_vars,
-    unwrap_coords,
     jax_data,
     jax_vars,
     apply_ufunc,
@@ -29,11 +25,7 @@ __all__ = [
     "get_jax_coords",
     "assign_jax_coords",
     # Wrapping/unwrapping (post JaxArrayWrapper removal)
-    "wrap",
-    "unwrap",
     "unwrap_data",
-    "unwrap_vars",
-    "unwrap_coords",
     "jax_data",
     "jax_vars",
     # Function application


### PR DESCRIPTION
# Abstract
This pull request removes the `JaxArrayWrapper` and its related methods in favor of directly using JAX arrays with xarray via the [Python Array API standard](https://data-apis.org/array-api/latest/API_specification/).

# Changes

- **Removed `JaxArrayWrapper` and its related utilities**
    - `wrap`
    - `_wrapped`
    - `unwrap`
    - `unwrap_coords`
    - `unwrap_vars`
- **Native JAX Array Support**: `xarray_jax.Variable`, `xarray_jax.DataArray`, and `xarray_jax.Dataset` constructors now accept raw `jax.Array` objects without any wrapping.
- **Cleaned Up Helper Functions**: All `wrap`/`unwrap` logic has been removed. The `jax_data` and `jax_vars` methods directly access Xarray data via `.data`.
- **Simplified `apply_ufunc`**: The `apply_ufunc` method no longer wraps and unwraps JAX arrays, effectively just provides type validation.
- **Updated Tests**: The tests have been updated to reflect the removal of `JaxArrayWrapper`.
    - Removed `test_jax_array_wrapper_with_numpy_api()`
    - Assert that Xarray data is an instance of `jax.Array` type instead of `xarray_jax.JaxArrayWrapper`

# Notes

## Using NumPy Functions

Since the `JaxArrayWrapper` is no longer used to dispatch NumPy functions to their JAX equivalents, Xarray-JAX now relies on the official Python Array API. Although this is best-practice, it affects how you should use NumPy functions with JAX-backed xarray objects, especially inside `@jax.jit`.

### Invalid: Automatic NumPy Dispatch

Previously, `JaxArrayWrapper` would automatically intercept a call like `np.abs()` and convert it to `jnp.abs()` behind the scenes. This meant the following code would work:

```python
da_jax = xr.DataArray(jnp.arange(...))
np.abs(da_jax_backed) # No longer automatically converts np.abs() -> jnp.abs()
```

Attempting this now will fail inside a JIT context, because `np.abs()` will try to convert the JAX tracer into a NumPy array, which is not allowed.

### Valid: JAX-Compatible Methods

To ensure your computation remains in the JAX ecosystem and is JIT-compatible, use one of the following patterns:

**1. Use Python's Built-in Functions and Operators:** Standard operators (`+`, `*`, etc.) and built-in functions like `abs()` will dispatch correctly to JAX's implementation. This is the preferred method.

```python
abs(da_jax) # Uses the Python built-in abs()
```

**2. Explicitly Apply the `jax.numpy` Function:** For functions that are not Python built-ins (e.g., `jnp.exp`, `jnp.sin`), use `apply_ufunc` to make it clear that you want to run the JAX version.

```python
apply_ufunc(jnp.exp, da_jax_backed) # Applies the JAX version of the function.
```

## Xarray Constructors

Given that JAX Arrays are natively supported as Xarray data via the Python Array API, the custom constructors in Xarray-JAX now solely exist to handle dynamic coordinates. If these dynamic coordinates are removed (per [Issue-3](https://github.com/mishasinitcyn/Xarray-JAX/issues/3)), these three constructors can be completely removed along with it, enabling developers to directly instantiate Xarray objects via `xr`.



Closes #1 