### PR TITLE
[Issue-2] Remove workarounds in assign_coords

### DIFF
--- a/tests/xarray_jax_test.py
+++ b/tests/xarray_jax_test.py
@@ -506,5 +506,53 @@ class XarrayJaxTest(absltest.TestCase):
     xarray.testing.assert_identical(expected[0], jax.device_get(result[0]))
     xarray.testing.assert_identical(expected[1], jax.device_get(result[1]))
 
+  def test_assign_coords(self):
+    inputs = xarray_jax.DataArray(
+        jnp.ones((3, 4)),
+        dims=['lat', 'lon'],
+        jax_coords={'lat': jnp.arange(3)},
+    )
+    self.assertIsInstance(inputs.coords['lat'].data, jax.Array)
+    self.assertNotIn('lat', inputs.indexes)
+
+    @jax.jit
+    def fn(data_array):
+      # Add a new jax_coord and a new static coord
+      data_array = xarray_jax.assign_coords(
+          data_array,
+          coords={'static_coord': 123},
+          jax_coords={'lon': jnp.arange(4) * 10},
+      )
+      # Overwrite an existing jax_coord
+      data_array = xarray_jax.assign_coords(
+          data_array,
+          jax_coords={'lat': jnp.arange(3) + 100},
+      )
+      # Overwrite an existing static coord
+      data_array = data_array.assign_coords(
+          coords={'static_coord': 456},
+      )
+
+      return data_array
+
+    _ = fn(inputs)
+    outputs = fn(inputs)
+
+    # The overwritten jax_coord should be correct
+    self.assertIn('lat', outputs.coords)
+    self.assertIsInstance(outputs.coords['lat'].data, jax.Array)
+    self.assertNotIn('lat', outputs.indexes)
+    chex.assert_trees_all_equal(outputs.coords['lat'].data, jnp.arange(3) + 100)
+
+    # The new jax_coord should be present and correct
+    self.assertIn('lon', outputs.coords)
+    self.assertIsInstance(outputs.coords['lon'].data, jax.Array)
+    self.assertNotIn('lon', outputs.indexes)
+    chex.assert_trees_all_equal(outputs.coords['lon'].data, jnp.arange(4) * 10)
+
+    # The static coord should be present and correctly overwritten
+    self.assertIn('static_coord', outputs.coords)
+    self.assertEqual(outputs.coords['static_coord'].data, 456)
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# Description

Removed the two workarounds for automatic indexing on jax_coords in custom `assign_coords()` method by using the `xarray.Coordinates` constructor initialized with `indexes={}`. This method now purely handles jax_coords logic. 

Also created a new test `test_assign_coords()`.

# Context

**Workaround 1: Dropping and re-adding JAX coordinates**
In the xarray_jax method assign_coords(), existing JAX coordinates were dropped and re-added to circumvent the Xarray indexing bug ([Issue #7885](https://github.com/pydata/xarray/issues/7885)). Now that this issue has been resolved, the minimal complete verifiable example passes all assertions:

```python
import xarray
import numpy as np
ds = xarray.Dataset(
    {'foo': (('x','y'), np.ones((3,5)))},
    coords={'x': [1,2,3], 'y': [4,5,6,7,8]})
ds = ds.drop_indexes('x')
assert 'x' not in ds.indexes
ds = ds.assign_coords(y=ds.y+1)
assert 'x' not in ds.indexes  # Passes
```

**Workaround 2: Temporarily renaming JAX coordinates to prevent eager NumPy conversion**
JAX coordinates that were also dimension coordinates were temporarily renamed with a `__NONINDEX_` prefix to prevent xarray from automatically creating a `pandas.Index`, which would eagerly convert the JAX array into a NumPy array and break JAX's tracing mechanism.

# Changes

Per the [xarray.Coordinates](https://docs.xarray.dev/en/latest/generated/xarray.Coordinates.html) documentation: 

> Parameters:
Indexes (dict-like, optional) - If None (default), pandas indexes will be created for each dimension coordinate. **Passing an empty dictionary will skip this default behavior**.
> 


Using this `xarray.Coordinates` constructor, we can avoid the two workarounds entirely. By passing `indexes={}`, we instruct xarray to assign coordinates without attempting to build an index for them. This is the desired behavior for our JAX-backed coordinates, as it preserves them as JAX arrays within the xarray structure.

### Changes Implemented

1. **Removed "drop and re-add" workaround**
2. **Remove the `__NONINDEX_` renaming workaround**
3. **Adopted `xarray.Coordinates`**
    - Regular (non-JAX) coordinates are assigned first using the standard `x.assign_coords()`
    - JAX coordinates (both new and existing) are then collected and assigned using `x.assign_coords(xarray.Coordinates(coords=jax_coords_dict, indexes={}))`
4. **Updated assign_coords comments**
    - Replaced the comment about workarounds with xarray.Coordinates implementation
    - Removed the comment about the workaround for Issue #7885 as it has been resolved


Closes #2 