### PR TITLE
[Issue-2] Remove workarounds in assign_coords 

### DIFF
--- a/src/xarray_jax/xarray_jax.py
+++ b/src/xarray_jax/xarray_jax.py
@@ -256,15 +256,9 @@ def assign_coords(
   xarray_jax.Dataset and xarray_jax.DataArray for more information.
 
   This function can be used to set jax_coords on an existing DataArray or
-  Dataset, and also to set a mix of jax and non-jax coordinates. It implements
-  some workarounds to prevent xarray trying and failing to create IndexVariables
-  from jax arrays under the hood.
-
-  If you have any jax_coords with the same name as a dimension, you'll need to
-  use this function instead of data_array.assign_coords or dataset.assign_coords
-  in general, to avoid an xarray bug where it tries (and in our case fails) to
-  create indexes for existing jax coords. See
-  https://github.com/pydata/xarray/issues/7885.
+  Dataset, and also to set a mix of jax and non-jax coordinates. It uses
+  xarray.Coordinates with empty indexes to prevent xarray trying and failing
+  to create IndexVariables from jax arrays under the hood.
 
   Args:
     x: An xarray Dataset or DataArray.
@@ -279,20 +273,15 @@ def assign_coords(
   coords = {} if coords is None else dict(coords)  # Copy before mutating.
   jax_coords = {} if jax_coords is None else dict(jax_coords)
 
-  # Any existing JAX coords must be dropped and re-added via the workaround
-  # below, since otherwise .assign_coords will trigger an xarray bug where
-  # it tries to recreate the indexes again for the existing coordinates.
-  # Can remove if/when https://github.com/pydata/xarray/issues/7885 fixed.
+  # Merge existing JAX coords with new ones
   existing_jax_coords = get_jax_coords(x)
   jax_coords = existing_jax_coords | jax_coords
-  x = x.drop_vars(existing_jax_coords.keys())
 
-  # We need to ensure that xarray doesn't try to create an index for
-  # coordinates with the same name as a dimension, since this will fail if
-  # given a wrapped JAX tracer.
-  # It appears the only way to avoid this is to name them differently to any
-  # dimension name, then rename them back afterwards.
-  renamed_jax_coords = {}
+  # Assign static coordinates with Xarray's native assign_coords()
+  if coords: x = x.assign_coords(coords)
+
+  # Convert jax_coords inputs to xarray.Variable objects
+  processed_jax_coords = {}
   for name, coord in jax_coords.items():
     if isinstance(coord, xarray.DataArray):
       coord = coord.variable
@@ -324,16 +313,13 @@ def assign_coords(
     # determine which coords need to be treated as leaves of the flattened
     # structure vs static data.
     coord.attrs[_JAX_COORD_ATTR_NAME] = True
-    renamed_jax_coords[f'__NONINDEX_{name}'] = coord
+    processed_jax_coords[name] = coord
 
-  x = x.assign_coords(coords=coords | renamed_jax_coords)
+  # Use xarray.Coordinates with empty indexes to skip automatic index creation
+  jax_coords_obj = xarray.Coordinates(coords=processed_jax_coords, indexes={})
+  x = x.assign_coords(jax_coords_obj)
 
-  rename_back_mapping = {f'__NONINDEX_{name}': name for name in jax_coords}
-  if isinstance(x, xarray.Dataset):
-    # Using 'rename' doesn't work if renaming to the same name as a dimension.
-    return x.rename_vars(rename_back_mapping)
-  else:  # DataArray
-    return x.rename(rename_back_mapping)
+  return x
 
 
 def get_jax_coords(x: DatasetOrDataArray) -> Mapping[Hashable, Any]:


### PR DESCRIPTION
# Description

Removed the two workarounds for automatic indexing on jax_coords in custom `assign_coords()` method by using the `xarray.Coordinates` constructor initialized with `indexes={}`. This method now purely handles jax_coords logic. 

Also created a new test `test_assign_coords()`.

# Context

**Workaround 1: Dropping and re-adding JAX coordinates**
In the xarray_jax method assign_coords(), existing JAX coordinates were dropped and re-added to circumvent the Xarray indexing bug ([Issue #7885](https://github.com/pydata/xarray/issues/7885)). Now that this issue has been resolved, the minimal complete verifiable example passes all assertions:

```python
import xarray
import numpy as np
ds = xarray.Dataset(
    {'foo': (('x','y'), np.ones((3,5)))},
    coords={'x': [1,2,3], 'y': [4,5,6,7,8]})
ds = ds.drop_indexes('x')
assert 'x' not in ds.indexes
ds = ds.assign_coords(y=ds.y+1)
assert 'x' not in ds.indexes  # Passes
```

**Workaround 2: Temporarily renaming JAX coordinates to prevent eager NumPy conversion**
JAX coordinates that were also dimension coordinates were temporarily renamed with a `__NONINDEX_` prefix to prevent xarray from automatically creating a `pandas.Index`, which would eagerly convert the JAX array into a NumPy array and break JAX's tracing mechanism.

# Changes

Per the [xarray.Coordinates](https://docs.xarray.dev/en/latest/generated/xarray.Coordinates.html) documentation: 

> Parameters:
Indexes (dict-like, optional) - If None (default), pandas indexes will be created for each dimension coordinate. **Passing an empty dictionary will skip this default behavior**.
> 


Using this `xarray.Coordinates` constructor, we can avoid the two workarounds entirely. By passing `indexes={}`, we instruct xarray to assign coordinates without attempting to build an index for them. This is the desired behavior for our JAX-backed coordinates, as it preserves them as JAX arrays within the xarray structure.

### Changes Implemented

1. **Removed "drop and re-add" workaround**
2. **Remove the `__NONINDEX_` renaming workaround**
3. **Use `xarray.Coordinates` directly**
    - Regular (non-JAX) coordinates are assigned first using the standard `x.assign_coords()`
    - All JAX coordinates are then processed and assigned using `jax_coords_obj = xarray.Coordinates(coords=processed_jax_coords, indexes={})`


Closes #2 